### PR TITLE
Add data storage on edges

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@
 indent_style = space
 end_of_line = lf
 charset = utf-8
-trim_trailing_whitespace = true
+trim_trailing_whitespace = false
 insert_final_newline = true
 max_line_length = 100
 indent_size = 2

--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ graph.addEdge(node1, node3)
 graph.addEdge(node3, node5)
 graph.addEdge(node5, node4)
 
+// Store data on edges
+graph.addEdge(node1, node5, {distance: 32})
+
+// Retrieve edge by node
+graph.getEdgeByNodes(node1, node5) // returns {data: {distance: 32}}
+
 // Get the nodes in topologically sorted order
 graph.topologicallySortedNodes() // returns roughly [{ name: 'node1' }, { name: 'node3' }, { name: 'node5' }, { name: 'node2' }, { name: 'node4' }]
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-graph",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-graph",
-  "version": "0.3.1",
+  "version": "0.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-graph",
-  "version": "0.0.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typescript-graph",
   "homepage": "https://segfaultx64.github.io/typescript-graph/",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "",
   "keywords": [],
   "main": "dist/typescript-graph.umd.js",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lint": "tslint  --projsect tsconfig.json -t codeFrame 'src/**/*.ts' 'test/**/*.ts' --fix",
     "prebuild": "rimraf dist",
     "build": "tsc --module commonjs && rollup -c rollup.config.ts && typedoc --out docs --target es6 --theme minimal --mode file src",
+    "prepack": "npm run build",
     "start": "rollup -c rollup.config.ts -w",
     "test": "jest --coverage",
     "test:watch": "jest --coverage --watch",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint": "tslint  --projsect tsconfig.json -t codeFrame 'src/**/*.ts' 'test/**/*.ts' --fix",
     "prebuild": "rimraf dist",
     "build": "tsc --module commonjs && rollup -c rollup.config.ts && typedoc --out docs --target es6 --theme minimal --mode file src",
-    "prepack": "npm run build",
+    "prepare": "npm run build",
     "start": "rollup -c rollup.config.ts -w",
     "test": "jest --coverage",
     "test:watch": "jest --coverage --watch",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typescript-graph",
   "homepage": "https://segfaultx64.github.io/typescript-graph/",
-  "version": "0.3.1",
+  "version": "0.3.3",
   "description": "",
   "keywords": [],
   "main": "dist/typescript-graph.umd.js",

--- a/src/directedAcyclicGraph.ts
+++ b/src/directedAcyclicGraph.ts
@@ -1,5 +1,5 @@
-import DirectedGraph from "./directedGraph";
-import { CycleError } from "./errors";
+import DirectedGraph, { AddDirectedEdgeOptions } from './directedGraph'
+import { CycleError } from './errors'
 
 /**
  * # DirectedAcyclicGraph
@@ -8,7 +8,7 @@ import { CycleError } from "./errors";
  *
  * @typeParam T `T` is the node type of the graph. Nodes can be anything in all the included examples they are simple objects.
  */
-export default class DirectedAcyclicGraph<T> extends DirectedGraph<T> {
+export default class DirectedAcyclicGraph<T, S = void> extends DirectedGraph<T, S> {
     private _topologicallySortedNodes?: Array<T>;
     protected hasCycle = false; 
 
@@ -17,12 +17,11 @@ export default class DirectedAcyclicGraph<T> extends DirectedGraph<T> {
      * Throws a {@linkcode CycleError} if the graph attempting to be converted contains a cycle.
      * @param graph The source directed graph to convert into a DAG
      */
-    static fromDirectedGraph<T>(graph: DirectedGraph<T>): DirectedAcyclicGraph<T> {
+    static fromDirectedGraph<T, S>(graph: DirectedGraph<T, S>): DirectedAcyclicGraph<T, S> {
         if (!graph.isAcyclic()) {
             throw new CycleError("Can't convert that graph to a DAG because it contains a cycle")
         }
-        const toRet = new DirectedAcyclicGraph<T>();
-
+        const toRet = new DirectedAcyclicGraph<T, S>();
         toRet.nodes = (graph as any).nodes
         toRet.adjacency = (graph as any).adjacency
 
@@ -36,15 +35,16 @@ export default class DirectedAcyclicGraph<T> extends DirectedGraph<T> {
      * 
      * @param fromNodeIdentity The identity string of the node the edge should run from.
      * @param toNodeIdentity The identity string of the node the edge should run to.
+     * @param {AddDirectedEdgeOptions} options - Options for adding edge
      */
-    addEdge(fromNodeIdentity: string, toNodeIdentity: string) {
+    addEdge(fromNodeIdentity: string, toNodeIdentity: string, options?: AddDirectedEdgeOptions<S>) {
         if (this.wouldAddingEdgeCreateCyle(fromNodeIdentity, toNodeIdentity)) {
             throw new CycleError(`Can't add edge from ${fromNodeIdentity} to ${toNodeIdentity} it would create a cycle`)
         }
 
         // Invalidate cache of toposorted nodes
         this._topologicallySortedNodes = undefined;
-        super.addEdge(fromNodeIdentity, toNodeIdentity, true)
+        super.addEdge(fromNodeIdentity, toNodeIdentity, { skipUpdatingCyclicality: true })
     }
 
     /**
@@ -77,7 +77,7 @@ export default class DirectedAcyclicGraph<T> extends DirectedGraph<T> {
         const nodeIndices = Array.from(this.nodes.keys());
         const nodeInDegrees = new Map(Array.from(this.nodes.keys()).map(n => [n, this.indegreeOfNode(n)]))
 
-        const adjCopy = this.adjacency.map(a => [...a])
+        const adjCopy = this.adjacency.map(a => [...a.map(e => ({ ...e }))])
 
         let toSearch = Array.from(nodeInDegrees).filter(pair => pair[1] === 0)
 
@@ -95,9 +95,9 @@ export default class DirectedAcyclicGraph<T> extends DirectedGraph<T> {
             toReturn.push(curNode);
 
             (adjCopy[nodeIndices.indexOf(n[0])])?.forEach((edge, index) => {
-                if (edge > 0) {
-                    adjCopy[nodeIndices.indexOf(n[0])][index] = 0;
-                    const target = (nodeInDegrees.get(nodeIndices[index]) as number);
+                if (edge.value > 0) {
+                    adjCopy[nodeIndices.indexOf(n[0])][index].value = 0;
+                    const target = nodeInDegrees.get(nodeIndices[index]) as number;
                     nodeInDegrees.set(nodeIndices[index], target - 1)
 
                     if ((target - 1) === 0) {
@@ -122,7 +122,7 @@ export default class DirectedAcyclicGraph<T> extends DirectedGraph<T> {
      * 
      * @param startNodeIdentity The string identity of the node from which the subgraph search should start.
      */
-    getSubGraphStartingFrom(startNodeIdentity: string): DirectedAcyclicGraph<T> {
+    getSubGraphStartingFrom(startNodeIdentity: string): DirectedAcyclicGraph<T, S> {
         return DirectedAcyclicGraph.fromDirectedGraph(super.getSubGraphStartingFrom(startNodeIdentity));
     }
 }

--- a/src/directedGraph.ts
+++ b/src/directedGraph.ts
@@ -6,7 +6,7 @@ import Graph, { AddEdgeOptions, Edge } from "./graph"
  * @typedef {AddEdgeOptions} AddDirectedEdgeOptions
  */
 export type AddDirectedEdgeOptions<S> = AddEdgeOptions<S> & {
-    skipUpdatingCyclicality: boolean
+    skipUpdatingCyclicality?: boolean
 }
 
 /**

--- a/src/directedGraph.ts
+++ b/src/directedGraph.ts
@@ -1,5 +1,13 @@
-import { NodeDoesntExistError } from "./errors";
-import Graph, { Edge } from "./graph";
+import { NodeDoesntExistError } from "./errors"
+import Graph, { AddEdgeOptions, Edge } from "./graph"
+
+/**
+ * Options for adding an edge
+ * @typedef {AddEdgeOptions} AddDirectedEdgeOptions
+ */
+export type AddDirectedEdgeOptions<S> = AddEdgeOptions<S> & {
+    skipUpdatingCyclicality: boolean
+}
 
 /**
  * # DirectedGraph
@@ -8,7 +16,7 @@ import Graph, { Edge } from "./graph";
  * 
  * @typeParam T `T` is the node type of the graph. Nodes can be anything in all the included examples they are simple objects.
  */
-export default class DirectedGraph<T> extends Graph<T> {
+export default class DirectedGraph<T, S = void> extends Graph<T, S> {
     /** Caches if the graph contains a cycle. If `undefined` then it is unknown. */
     protected hasCycle?: boolean;
 
@@ -37,7 +45,7 @@ export default class DirectedGraph<T> extends Graph<T> {
 
             const nodeIndex = nodeIndices.indexOf(cur[0]);
             this.adjacency[nodeIndex].forEach((hasAdj, index) => {
-                if (hasAdj === 1) {
+                if (hasAdj && hasAdj.value === 1) {
                     const currentInDegree = nodeInDegrees.get(nodeIndices[index]);
                     if (currentInDegree !== undefined) {
                         nodeInDegrees.set(nodeIndices[index], currentInDegree - 1)
@@ -72,7 +80,7 @@ export default class DirectedGraph<T> extends Graph<T> {
         }
 
         return this.adjacency.reduce<number>((carry, row) => {
-            return carry + ((row[indexOfNode] > 0)? 1 : 0);
+            return carry + ((row[indexOfNode].value > 0)? 1 : 0);
         }, 0)
     }
 
@@ -81,17 +89,23 @@ export default class DirectedGraph<T> extends Graph<T> {
      * 
      * @param fromNodeIdentity The identity string of the node the edge should run from. 
      * @param toNodeIdentity The identity string of the node the edge should run to.
-     * @param skipUpdatingCyclicality This boolean indicates if the cache of the cyclicality of the graph should be updated.
+     * @param options options
+     *  skipUpdatingCyclicality: This boolean indicates if the cache of the cyclicality of the graph should be updated.
      * If `false` is passed the cached will be invalidated because we can not assure that a cycle has not been created.
+     *  data: optional extra data to add to edge
      */
-    addEdge(fromNodeIdentity: string, toNodeIdentity: string, skipUpdatingCyclicality: boolean = false) {
-        if (!this.hasCycle && !skipUpdatingCyclicality) {
+    addEdge(
+      fromNodeIdentity: string,
+      toNodeIdentity: string,
+      options: AddDirectedEdgeOptions<S> = { skipUpdatingCyclicality: false }
+    ) {
+        if (!this.hasCycle && !options.skipUpdatingCyclicality) {
             this.hasCycle = this.wouldAddingEdgeCreateCyle(fromNodeIdentity, toNodeIdentity);
-        } else if (skipUpdatingCyclicality) {
+        } else if (options.skipUpdatingCyclicality) {
             this.hasCycle = undefined;
         }
-
-        super.addEdge(fromNodeIdentity, toNodeIdentity)
+    
+        super.addEdge(fromNodeIdentity, toNodeIdentity, options)
     }
 
     /**
@@ -107,12 +121,12 @@ export default class DirectedGraph<T> extends Graph<T> {
         const startNodeIndex = nodeIdentities.indexOf(startNode);
         const endNodeIndex = nodeIdentities.indexOf(endNode);
 
-        if (this.adjacency[startNodeIndex][endNodeIndex] > 0) {
+        if (this.adjacency[startNodeIndex][endNodeIndex].value > 0) {
             return true
         }
 
         return this.adjacency[startNodeIndex].reduce<boolean>((carry, edge, index) => {
-            if (carry || (edge < 1)) {
+            if (carry || (edge.value < 1)) {
                 return carry;
             }
 
@@ -137,7 +151,7 @@ export default class DirectedGraph<T> extends Graph<T> {
      * 
      * @param startNodeIdentity The string identity of the node from which the subgraph search should start.
      */
-    getSubGraphStartingFrom(startNodeIdentity: string): DirectedGraph<T> {
+    getSubGraphStartingFrom(startNodeIdentity: string): DirectedGraph<T, S> {
         const nodeIndices = Array.from(this.nodes.keys());
         const initalNode = this.nodes.get(startNodeIdentity)
 
@@ -149,7 +163,7 @@ export default class DirectedGraph<T> extends Graph<T> {
             let toReturn = [...nodesToInclude];
             const nodeIndex = nodeIndices.indexOf(startNodeIdentity);
             this.adjacency[nodeIndex].forEach((hasAdj, index) => {
-                if (hasAdj === 1 && !nodesToInclude.find(n => this.nodeIdentity(n) === nodeIndices[index])) {
+                if (hasAdj.value === 1 && !nodesToInclude.find(n => this.nodeIdentity(n) === nodeIndices[index])) {
                     const newNode = this.nodes.get(nodeIndices[index])
                     
                     if (newNode) {
@@ -161,7 +175,7 @@ export default class DirectedGraph<T> extends Graph<T> {
             return toReturn;
         }
 
-        const newGraph = new DirectedGraph<T>(this.nodeIdentity);
+        const newGraph = new DirectedGraph<T, S>(this.nodeIdentity)
         const nodeList = recur(startNodeIdentity, [initalNode])
         const includeIdents = nodeList.map(t => this.nodeIdentity(t));
         Array.from(this.nodes.values()).forEach(n => {
@@ -173,11 +187,11 @@ export default class DirectedGraph<T> extends Graph<T> {
         return newGraph
     }
 
-    private subAdj(include: T[]): Array<Array<Edge>> {
+    private subAdj(include: T[]): Array<Array<Edge<S>>> {
         const includeIdents = include.map(t => this.nodeIdentity(t));
         const nodeIndices = Array.from(this.nodes.keys());
 
-        return this.adjacency.reduce<Array<Array<Edge>>>((carry, cur, index) => {
+        return this.adjacency.reduce<Array<Array<Edge<S>>>>((carry, cur, index) => {
             if (includeIdents.includes(nodeIndices[index])) {
                 return [...carry, cur.filter((_, index) => includeIdents.includes(nodeIndices[index]))]
             } else {

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -9,8 +9,14 @@ const hash = require('object-hash')
  * @internal
  * This type is simply an indicator of whether an edge exists in the adjacency matrix.
  */
-export type Edge = 1 | 0
+export type Edge<S = void> = {
+  value: 1 | 0
+  data?: S
+}
 
+export type AddEdgeOptions<S = void> = {
+  data?: S
+}
 /**
  * # Graph
  *
@@ -97,9 +103,9 @@ export type Edge = 1 | 0
  *
  * @typeParam T  `T` is the node type of the graph. Nodes can be anything in all the included examples they are simple objects.
  */
-export default class Graph<T> {
+export default class Graph<T, S = void> {
   protected nodes: Map<string, T>
-  protected adjacency: Array<Array<Edge>>
+  protected adjacency: Array<Array<Edge<S>>>
   protected nodeIdentity: (t: T) => string
 
   constructor(nodeIdentity: (node: T) => string = node => hash(node)) {
@@ -126,8 +132,8 @@ export default class Graph<T> {
     }
 
     this.nodes.set(this.nodeIdentity(node), node)
-    this.adjacency.map(adj => adj.push(0))
-    this.adjacency.push(new Array(this.adjacency.length + 1).fill(0))
+    this.adjacency.map(adj => adj.push({ value: 0 }))
+    this.adjacency.push(new Array(this.adjacency.length + 1).fill({ value: 0 }))
 
     return this.nodeIdentity(node)
   }
@@ -163,7 +169,7 @@ export default class Graph<T> {
     this.nodes.set(this.nodeIdentity(node), node)
 
     if (!isOverwrite) {
-      this.adjacency.map(adj => adj.push(0))
+      this.adjacency.map(adj => adj.push({ value: 0 }))
       this.adjacency.push(new Array(this.adjacency.length + 1))
     }
 
@@ -176,8 +182,9 @@ export default class Graph<T> {
    *
    * @param node1Identity The first node to connect (in [[`DirectedGraph`]]s and [[`DirectedAcyclicGraph`]]s this is the `from` node.)
    * @param node2Identity The second node to connect (in [[`DirectedGraph`]]s and [[`DirectedAcyclicGraph`]]s this is the `to` node)
+   * @param options options
    */
-  addEdge(node1Identity: string, node2Identity: string) {
+  addEdge(node1Identity: string, node2Identity: string, options?: AddEdgeOptions<S>) {
     const node1Exists = this.nodes.has(node1Identity)
     const node2Exists = this.nodes.has(node2Identity)
 
@@ -192,7 +199,10 @@ export default class Graph<T> {
     const node1Index = Array.from(this.nodes.keys()).indexOf(node1Identity)
     const node2Index = Array.from(this.nodes.keys()).indexOf(node2Identity)
 
-    this.adjacency[node1Index][node2Index] = 1
+    this.adjacency[node1Index][node2Index] = { value: 1 }
+    if (options?.data) {
+      this.adjacency[node1Index][node2Index].data = options.data
+    }
   }
 
   /**
@@ -210,10 +220,16 @@ export default class Graph<T> {
     return temp
   }
 
+  getEdgeByNodes(node1Identity: string, node2Identity: string): Edge<S> {
+    const node1Index = Array.from(this.nodes.keys()).indexOf(node1Identity)
+    const node2Index = Array.from(this.nodes.keys()).indexOf(node2Identity)
+    return this.adjacency[node1Index][node2Index]
+  }
+
   /**
    * Returns a specific node given the node identity returned from the [[`insert`]] function
    *
-   * @param compareFunc An optional function that indicates the sort order of the returned array
+   * @param nodeIdentity Identifier of the node
    */
   getNode(nodeIdentity: string): T | undefined {
     return this.nodes.get(nodeIdentity)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import DirectedAcyclicGraph from './directedAcyclicGraph'
 import DirectedGraph from './directedGraph'
 import Graph, { Edge } from './graph'
+export * from './errors'
 
 export { Graph, DirectedGraph, Edge, DirectedAcyclicGraph }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import DirectedAcyclicGraph from "./directedAcyclicGraph"
-import DirectedGraph from "./directedGraph"
-import Graph from "./graph"
+import DirectedAcyclicGraph from './directedAcyclicGraph'
+import DirectedGraph from './directedGraph'
+import Graph, { Edge } from './graph'
 
-export { Graph, DirectedGraph, DirectedAcyclicGraph };
+export { Graph, DirectedGraph, Edge, DirectedAcyclicGraph }

--- a/test/directedAcyclicGraph.test.ts
+++ b/test/directedAcyclicGraph.test.ts
@@ -23,7 +23,7 @@ describe("Directed Acyclic Graph", () => {
     graph.addEdge('A', 'C')
 
     expect(DirectedAcyclicGraph.fromDirectedGraph(graph)).toBeInstanceOf(DirectedAcyclicGraph)
-    
+
     graph.addEdge('C', 'A')
 
     expect(() => DirectedAcyclicGraph.fromDirectedGraph(graph)).toThrow(CycleError)
@@ -67,13 +67,13 @@ describe("Directed Acyclic Graph", () => {
     const topoList2 = graph.topologicallySortedNodes();
 
     expect(topoList2).toEqual([{ name: 'A' }, { name: 'C' }, { name: 'B' }])
-    
+
     graph.insert({ name: 'D' })
     graph.insert({ name: 'E' })
 
     graph.addEdge('A', 'D')
     graph.addEdge('B', 'E')
-    
+
     const topoList3 = graph.topologicallySortedNodes();
 
     expect(topoList3[0]).toEqual({ name: 'A' })

--- a/test/directedGraph.test.ts
+++ b/test/directedGraph.test.ts
@@ -1,4 +1,4 @@
-import { DirectedGraph, Graph } from '../src/'
+import { DirectedGraph } from '../src/'
 import { NodeDoesntExistError } from '../src/errors'
 
 /***
@@ -195,7 +195,7 @@ describe("Directed Graph", () => {
     graph.addEdge('B', 'D')
 
     const subGraph3 = graph.getSubGraphStartingFrom('A');
-    
+
     expect(subGraph3.getNodes()).toContainEqual({ name: 'D' })
     expect(subGraph3.canReachFrom('A', 'C')).toBe(true);
     expect(subGraph3.canReachFrom('A', 'D')).toBe(true);

--- a/test/graph.test.ts
+++ b/test/graph.test.ts
@@ -137,14 +137,40 @@ describe('Graph', () => {
     graph.insert({ a: 4, b: 'b' })
 
     graph.addEdge('1.00', '2.00')
-    expect((graph as any).adjacency[0][1]).toBe(1)
-    expect((graph as any).adjacency[1][0]).toBeFalsy()
-    expect((graph as any).adjacency[1][2]).toBe(0)
+    expect((graph as any).adjacency[0][1]).toEqual({value: 1})
+    expect((graph as any).adjacency[1][0].value).toBeFalsy()
+    expect((graph as any).adjacency[1][2]).toEqual({value: 0})
 
     graph.addEdge('2.00', '1.00')
-    expect((graph as any).adjacency[0][1]).toBe(1)
-    expect((graph as any).adjacency[1][0]).toBe(1)
-    expect((graph as any).adjacency[1][2]).toBeFalsy()
+    expect((graph as any).adjacency[0][1]).toEqual({value: 1})
+    expect((graph as any).adjacency[1][0]).toEqual({value: 1})
+    expect((graph as any).adjacency[1][2].value).toBeFalsy()
+  })
+
+  it('can store data on edges', () => {
+    type NodeType = { name: string }
+    type EdgeData = { weight: number; label: string }
+
+    const graph = new Graph<NodeType, EdgeData>((n: NodeType) => n.name)
+
+    // Insert nodes
+    graph.insert({ name: 'A' })
+    graph.insert({ name: 'B' })
+    graph.insert({ name: 'C' })
+
+    // Add edges with data
+    graph.addEdge('A', 'B', { data: { weight: 5, label: 'connection1' } })
+    graph.addEdge('B', 'C', { data: { weight: 10, label: 'connection2' } })
+    graph.addEdge('A', 'C', { data: { weight: 3, label: 'shortcut' } })
+
+    // Verify edges exist and has the data
+    const edge1 = graph.getEdgeByNodes('A', 'B');
+    const edge2 = graph.getEdgeByNodes('B', 'C');
+    const edge3 = graph.getEdgeByNodes('A', 'C');
+
+    expect(edge1.data?.weight).toBe(5);
+    expect(edge2.data?.weight).toBe(10);
+    expect(edge3.data?.weight).toBe(3);
   })
 
   it('can return the nodes', () => {


### PR DESCRIPTION
This feature adds optional data storage on edges and a method to retrieve edges by node names.

The change should be backwards compatible.
